### PR TITLE
fix: disallow deposit funds to expired agreement

### DIFF
--- a/contracts/StorageManager.sol
+++ b/contracts/StorageManager.sol
@@ -227,6 +227,8 @@ contract StorageManager {
     @notice deposits new funds to the Agreement.
     @dev
         - depositing funds to Agreement that is linked to terminated Offer is not possible
+        - depositing funds to Agreement that already is expired (eq. ran out of funds at some point) is not possible.
+          Call NewAgreement instead. The data needs to be re-provided though.
     @param dataReference data reference where should be deposited funds.
     @param provider the address of the provider of the Offer.
     */
@@ -237,6 +239,7 @@ contract StorageManager {
 
         require(agreement.lastPayoutDate != 0, "StorageManager: Agreement not active");
         require(offer.billingPlans[agreement.billingPeriod] == agreement.billingPrice, "StorageManager: Price not available anymore");
+        require(agreement.availableFunds - _calculateSpentFunds(agreement) > agreement.billingPrice * agreement.size, "StorageManager: Agreement already ran out of funds");
 
         agreement.availableFunds = agreement.availableFunds.add(msg.value);
         emit AgreementFundsDeposited(agreementReference, msg.value);

--- a/contracts/TestStorageManager.sol
+++ b/contracts/TestStorageManager.sol
@@ -6,10 +6,6 @@ contract TestStorageManager is StorageManager {
     uint time;
 
     function _time() internal view override returns (uint) {
-        if(time == 0){
-            return now;
-        }
-
         return time;
     }
 

--- a/test/StorageManager.test.js
+++ b/test/StorageManager.test.js
@@ -294,6 +294,18 @@ contract('StorageManager', ([Provider, Consumer, randomPerson]) => {
       await expectRevert(storageManager.depositFunds(cid, Provider, { from: Consumer, value: 100 }),
         'StorageManager: Agreement not active')
     })
+
+    it('should revert when agreement ran out of funds', async () => {
+      await storageManager.setOffer(1000, [1, 100], [10, 80], [], { from: Provider })
+      await storageManager.newAgreement(cid, Provider, 100, 1, [], {
+        from: Consumer,
+        value: 1500
+      })
+      await storageManager.incrementTime(2)
+
+      await expectRevert(storageManager.depositFunds(cid, Provider, { from: Consumer, value: 100 }),
+        'StorageManager: Agreement already ran out of funds')
+    })
   })
 
   describe('withdrawFunds', function () {


### PR DESCRIPTION
Needs to be finished:

 - [x] fix the `should revert when agreement already exists with running funds` testcase as it is not true anymore
 - [x] write another test case that validate that the payout happens when newAgreement is called for active agreement
