### PR TITLE
fix: depositFunds strict check for billing plans

### DIFF
--- a/contracts/StorageManager.sol
+++ b/contracts/StorageManager.sol
@@ -236,7 +236,7 @@ contract StorageManager {
         Agreement storage agreement = offer.agreementRegistry[agreementReference];
 
         require(agreement.lastPayoutDate != 0, "StorageManager: Agreement not active");
-        require(offer.billingPlans[agreement.billingPeriod] != 0, "StorageManager: Price not available anymore");
+        require(offer.billingPlans[agreement.billingPeriod] == agreement.billingPrice, "StorageManager: Price not available anymore");
 
         agreement.availableFunds = agreement.availableFunds.add(msg.value);
         emit AgreementFundsDeposited(agreementReference, msg.value);
@@ -283,7 +283,7 @@ contract StorageManager {
     /**
     >> FOR PROVIDER
     @notice payout already earned funds of one or more Agreement
-    @dev 
+    @dev
     - Provider must call an expired agreement themselves as soon as the agreement is expired, to add back the capacity to their Offer.
     @param agreementReferences reference to one or more Agreement
     */

--- a/test/StorageManager.test.js
+++ b/test/StorageManager.test.js
@@ -273,6 +273,15 @@ contract('StorageManager', ([Provider, Consumer, randomPerson]) => {
         'StorageManager: Price not available anymore')
     })
 
+    it('should revert when billing plans has changed', async () => {
+      await storageManager.setOffer(1000, [10, 100], [10, 80], [], { from: Provider })
+      await storageManager.newAgreement(cid, Provider, 100, 10, [], { from: Consumer, value: 2000 })
+      await storageManager.setBillingPlans([10, 100], [50, 80], { from: Provider })
+
+      await expectRevert(storageManager.depositFunds(cid, Provider, { from: Consumer, value: 100 }),
+        'StorageManager: Price not available anymore')
+    })
+
     it('should revert when agreement is expired', async () => {
       await storageManager.setOffer(1000, [1, 100], [10, 80], [], { from: Provider })
       const agreementReference = getAgreementReference(await storageManager.newAgreement(cid, Provider, 100, 1, [], {


### PR DESCRIPTION
When Billing Plans change the deposit funds should not be allowed in
order to force the Consumer to migrate to next billing plan.

Until now it was asserted that a billing plan for given billing period
exists but not that the price did not change. This patch fix that.

Related to #87 