### PR TITLE
chore: added config for ganache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21641,9 +21641,9 @@
       "dev": true
     },
     "truffle": {
-      "version": "5.1.34",
-      "resolved": "https://registry.npmjs.org/truffle/-/truffle-5.1.34.tgz",
-      "integrity": "sha512-Z+EWLI8TOqRbPOu7PhhdFZ0EypIf+1wA6Z9UPKx2LMjX9uQzCl4e+d20Qvfz9uD/2C//pJlvXbyXu9LuYeumgQ==",
+      "version": "5.1.37",
+      "resolved": "https://registry.npmjs.org/truffle/-/truffle-5.1.37.tgz",
+      "integrity": "sha512-ONIrN/OjtWgPl/qe74lcoUXZm3b04Omq8sbsPuMF7w/8uOx7/sufxd99UfKInxjCZnryD2tQHdYQbNvoXyvpgQ==",
       "dev": true,
       "requires": {
         "app-module-path": "^2.2.0",
@@ -22756,9 +22756,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.6.tgz",
-      "integrity": "sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==",
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
       "dev": true
     },
     "typical": {
@@ -24733,13 +24733,13 @@
       }
     },
     "web3-utils": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.9.tgz",
-      "integrity": "sha512-9hcpuis3n/LxFzEVjwnVgvJzTirS2S9/MiNAa7l4WOEoywY+BSNwnRX4MuHnjkh9NY25B6QOjuNG6FNnSjTw1w==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.11.tgz",
+      "integrity": "sha512-3Tq09izhD+ThqHEaWYX4VOT7dNPdZiO+c/1QMA0s5X2lDFKK/xHJb7cyTRRVzN2LvlHbR7baS1tmQhSua51TcQ==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "eth-lib": "0.2.7",
+        "bn.js": "^4.11.9",
+        "eth-lib": "0.2.8",
         "ethereum-bloom-filters": "^1.0.6",
         "ethjs-unit": "0.1.6",
         "number-to-bn": "1.7.0",
@@ -24748,10 +24748,16 @@
         "utf8": "3.0.0"
       },
       "dependencies": {
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
+          "dev": true
+        },
         "eth-lib": {
-          "version": "0.2.7",
-          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
-          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
           "dev": true,
           "requires": {
             "bn.js": "^4.11.6",

--- a/package.json
+++ b/package.json
@@ -38,18 +38,18 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@openzeppelin/test-helpers": "^0.5.5",
+    "@openzeppelin/test-helpers": "^0.5.6",
     "@typechain/ethers-v4": "^1.0.0",
     "@typechain/truffle-v4": "^2.0.3",
     "@typechain/truffle-v5": "^2.0.2",
     "@typechain/web3-v1": "^1.0.0",
     "chai": "^4.2.0",
     "tasegir": "^1.7.1",
-    "truffle": "^5.1.24",
-    "truffle-security": "^1.6.2",
+    "truffle": "^5.1.37",
+    "truffle-security": "^1.7.3",
     "typechain": "^2.0.0",
-    "typescript": "^3.8.3",
-    "web3-utils": "^1.2.7"
+    "typescript": "^3.9.7",
+    "web3-utils": "^1.2.11"
   },
   "engines": {
     "node": ">=10.0.0",

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -38,6 +38,11 @@ module.exports = {
    */
 
   networks: {
+    ganache: {
+     host: "127.0.0.1",     // Localhost (default: none)
+     port: 8545,            // Standard Ethereum port (default: none)
+     network_id: "*",       // Any network (default: none)
+    },
     // Useful for testing. The `development` name is special - truffle uses it by default
     // if it's defined here and no other network is specified at the command line.
     // You should run a client (like ganache-cli, geth or parity) in a separate terminal


### PR DESCRIPTION
Replaces #70 

You can now use `npx truffle deploy --network ganache`