### PR TITLE
feat: adjust NewAgreement event

### DIFF
--- a/contracts/StorageManager.sol
+++ b/contracts/StorageManager.sol
@@ -63,6 +63,7 @@ contract StorageManager is Ownable, Pausable {
         address indexed provider,
         uint128 size,
         uint64 billingPeriod,
+        uint128 billingPrice,
         address token,
         uint256 availableFunds
     );
@@ -249,6 +250,7 @@ contract StorageManager is Ownable, Pausable {
             provider,
             size,
             billingPeriod,
+            billingPrice,
             token,
             agreement.availableFunds
         );

--- a/contracts/StorageManager.sol
+++ b/contracts/StorageManager.sol
@@ -58,7 +58,7 @@ contract StorageManager is Ownable, Pausable {
     event MessageEmitted(address indexed provider, bytes32[] message);
 
     event NewAgreement(
-        bytes32 dataReference,
+        bytes32[] dataReference,
         address indexed agreementCreator,
         address indexed provider,
         uint128 size,

--- a/contracts/StorageManager.sol
+++ b/contracts/StorageManager.sol
@@ -58,12 +58,12 @@ contract StorageManager is Ownable, Pausable {
     event MessageEmitted(address indexed provider, bytes32[] message);
 
     event NewAgreement(
-        bytes32 agreementReference,
+        bytes32 dataReference,
         address indexed agreementCreator,
         address indexed provider,
         uint128 size,
         uint64 billingPeriod,
-        uint128 billingPrice,
+        address token,
         uint256 availableFunds
     );
     event AgreementFundsDeposited(bytes32 indexed agreementReference, uint256 amount, address indexed token);
@@ -244,12 +244,12 @@ contract StorageManager is Ownable, Pausable {
         require(offer.utilizedCapacity <= offer.totalCapacity, "StorageManager: Insufficient Offer's capacity");
 
         emit NewAgreement(
-            agreementReference,
+            dataReference,
             msg.sender,
             provider,
             size,
             billingPeriod,
-            billingPrice,
+            token,
             agreement.availableFunds
         );
     }

--- a/test/StorageManager.test.js
+++ b/test/StorageManager.test.js
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires,no-undef */
+const { soliditySha3 } = require('web3-utils')
+
 const {
   expectEvent,
   expectRevert,
@@ -12,7 +14,7 @@ const ERC20 = artifacts.require('MockERC20')
 
 function getAgreementReference (receipt) {
   const newAgreementEvent = receipt.logs.find(e => e.event === 'NewAgreement')
-  return newAgreementEvent.args.agreementReference
+  return soliditySha3(newAgreementEvent.args.agreementCreator, ...newAgreementEvent.args.dataReference, newAgreementEvent.args.token)
 }
 
 contract('StorageManager', ([Provider, Consumer, Owner]) => {
@@ -116,7 +118,7 @@ contract('StorageManager', ([Provider, Consumer, Owner]) => {
           agreementCreator: Consumer,
           size: '100',
           billingPeriod: '10',
-          token: token.address,
+          token: constants.ZERO_ADDRESS,
           availableFunds: '2000'
         })
         await expectUtilizedCapacity(100)
@@ -153,7 +155,7 @@ contract('StorageManager', ([Provider, Consumer, Owner]) => {
           agreementCreator: Consumer,
           size: '100',
           billingPeriod: '10',
-          token: token.address,
+          token: constants.ZERO_ADDRESS,
           availableFunds: '2000'
         })
         await expectUtilizedCapacity(100)
@@ -174,7 +176,7 @@ contract('StorageManager', ([Provider, Consumer, Owner]) => {
           agreementCreator: Owner,
           size: '100',
           billingPeriod: '10',
-          token: token.address,
+          token: constants.ZERO_ADDRESS,
           availableFunds: '2000'
         })
         await expectUtilizedCapacity(200)
@@ -189,7 +191,7 @@ contract('StorageManager', ([Provider, Consumer, Owner]) => {
           agreementCreator: Consumer,
           size: '100',
           billingPeriod: '10',
-          billingPrice: '10',
+          token: token.address,
           availableFunds: '2000'
         })
         await expectUtilizedCapacity(100)
@@ -312,7 +314,7 @@ contract('StorageManager', ([Provider, Consumer, Owner]) => {
         agreementCreator: Consumer,
         size: '100',
         billingPeriod: '2',
-        token: token.address,
+        token: constants.ZERO_ADDRESS,
         availableFunds: '2500'
       })
     })
@@ -344,7 +346,7 @@ contract('StorageManager', ([Provider, Consumer, Owner]) => {
         agreementCreator: Consumer,
         size: '200',
         billingPeriod: '10',
-        token: token.address,
+        token: constants.ZERO_ADDRESS,
         availableFunds: '2000'
       })
       expectEvent(receipt, 'AgreementFundsPayout', {

--- a/test/StorageManager.test.js
+++ b/test/StorageManager.test.js
@@ -116,7 +116,7 @@ contract('StorageManager', ([Provider, Consumer, Owner]) => {
           agreementCreator: Consumer,
           size: '100',
           billingPeriod: '10',
-          billingPrice: '10',
+          token: token.address,
           availableFunds: '2000'
         })
         await expectUtilizedCapacity(100)
@@ -136,7 +136,7 @@ contract('StorageManager', ([Provider, Consumer, Owner]) => {
           agreementCreator: Consumer,
           size: '100',
           billingPeriod: '10',
-          billingPrice: '10',
+          token: token.address,
           availableFunds: '2000'
         })
         await expectUtilizedCapacity(100)
@@ -153,7 +153,7 @@ contract('StorageManager', ([Provider, Consumer, Owner]) => {
           agreementCreator: Consumer,
           size: '100',
           billingPeriod: '10',
-          billingPrice: '10',
+          token: token.address,
           availableFunds: '2000'
         })
         await expectUtilizedCapacity(100)
@@ -174,7 +174,7 @@ contract('StorageManager', ([Provider, Consumer, Owner]) => {
           agreementCreator: Owner,
           size: '100',
           billingPeriod: '10',
-          billingPrice: '10',
+          token: token.address,
           availableFunds: '2000'
         })
         await expectUtilizedCapacity(200)
@@ -210,7 +210,7 @@ contract('StorageManager', ([Provider, Consumer, Owner]) => {
           agreementCreator: Owner,
           size: '100',
           billingPeriod: '10',
-          billingPrice: '10',
+          token: token.address,
           availableFunds: '2000'
         })
         await expectUtilizedCapacity(200)
@@ -312,7 +312,7 @@ contract('StorageManager', ([Provider, Consumer, Owner]) => {
         agreementCreator: Consumer,
         size: '100',
         billingPeriod: '2',
-        billingPrice: '20',
+        token: token.address,
         availableFunds: '2500'
       })
     })
@@ -344,7 +344,7 @@ contract('StorageManager', ([Provider, Consumer, Owner]) => {
         agreementCreator: Consumer,
         size: '200',
         billingPeriod: '10',
-        billingPrice: '10',
+        token: token.address,
         availableFunds: '2000'
       })
       expectEvent(receipt, 'AgreementFundsPayout', {


### PR DESCRIPTION
This will allow us to map the right billing plan with token using `token` and `billingPeriod`. Agreement reference can be manually generated using: `keccak256([dataReference, creator, token])`

- Replace `agreementReference` with `dataReference`